### PR TITLE
Add more M2IOStream stuff

### DIFF
--- a/tornado_m2crypto/netutil.py
+++ b/tornado_m2crypto/netutil.py
@@ -4,7 +4,7 @@ from myDebug import printDebug
 # These are the keyword arguments to ssl.wrap_socket that must be translated
 # to their SSLContext equivalents (the other arguments are still passed
 # to SSLContext.wrap_socket).
-_SSL_CONTEXT_KEYWORDS = frozenset(['ssl_version', 'certfile', 'keyfile',
+_SSL_CONTEXT_KEYWORDS = frozenset(['ssl_version', 'certfile', 'keyfile', 'dhparam',
                                    'cert_reqs', 'verify_depth', 'ca_certs', 'ciphers'])
 
 @printDebug
@@ -72,6 +72,8 @@ def ssl_options_to_m2_context(ssl_options):
         print "ALL OK"
     if 'ciphers' in ssl_options:
         context.set_cipher_list(ssl_options['ciphers'])
+    if 'dhparam' in ssl_options:
+        context.set_tmp_dh(ssl_options['dhparam'])
     # if hasattr(ssl, 'OP_NO_COMPRESSION'):
     #     # Disable TLS compression to avoid CRIME and related attacks.
     #     # This constant depends on openssl version 1.0.
@@ -96,5 +98,12 @@ def m2_wrap_socket(socket, ssl_options, server_hostname=None, **kwargs):
 
     # if server_hostname:
     #   connection.set_tlsext_host_name(server_hostname)
+
+    if 'server_side' in kwargs:
+        connection.server_side = kwargs['server_side']
+    else:
+        connection.server_side = False
+
+    connection.family = socket.family
 
     return connection

--- a/tornado_m2crypto/test/m2io_https.py
+++ b/tornado_m2crypto/test/m2io_https.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Simple HTTPS test server
+# Run with: tox -e m2io_https
+# Client: curl -k -v https://localhost:12345
+
+
+SSL_OPTS = {
+  'certfile': 'tornado_m2crypto/test/test.crt',
+  'keyfile':  'tornado_m2crypto/test/test.key',
+}
+
+# Patching
+from tornado_m2crypto.netutil import m2_wrap_socket
+import tornado.netutil
+tornado.netutil.ssl_wrap_socket = m2_wrap_socket
+
+import tornado.iostream
+tornado.iostream.SSLIOStream.configure('tornado_m2crypto.m2iostream.M2IOStream')
+
+
+
+import tornado.httpserver
+import tornado.ioloop
+import tornado.web
+
+class getToken(tornado.web.RequestHandler):
+    def get(self):
+        self.write("hello\n\n")
+
+application = tornado.web.Application([
+    (r'/', getToken),
+])
+
+if __name__ == '__main__':
+    http_server = tornado.httpserver.HTTPServer(application, ssl_options=SSL_OPTS)
+    http_server.listen(12345)
+    tornado.ioloop.IOLoop.instance().start()
+
+

--- a/tornado_m2crypto/test/m2iostream_test.py
+++ b/tornado_m2crypto/test/m2iostream_test.py
@@ -4,6 +4,7 @@ from tornado import gen
 from tornado import netutil
 from tornado.iostream import IOStream, PipeIOStream, StreamClosedError, _StreamBuffer,SSLIOStream
 from tornado_m2crypto.m2iostream import M2IOStream
+from tornado_m2crypto.netutil import m2_wrap_socket
 from tornado.httputil import HTTPHeaders
 from tornado.locks import Condition, Event
 from tornado.log import gen_log, app_log
@@ -1078,9 +1079,12 @@ class TestIOStreamM2(TestIOStreamMixin, AsyncTestCase):
 
         ssl_options = _server_ssl_options()
         ssl_options['cert_reqs'] = SSL.verify_none
-        ssl_options['asServer'] = True
+        # We have to enable server_side mode on this one
+        connection = m2_wrap_socket(connection, ssl_options,
+                                    server_side=True)
         # kwargs['ssl_options'] = ssl_options
-        return SSLIOStream(connection, ssl_options = ssl_options, **kwargs)
+        stream = SSLIOStream(connection, ssl_options = ssl_options, **kwargs)
+        return stream
 
     def _make_client_iostream(self, connection, **kwargs):
         ssl_options = _server_ssl_options()

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,13 @@
 envlist = py27
 
 [testenv]
+basepython=python2.7
 deps = -rmaint/requirements.txt
 
 commands = python tornado_m2crypto/test/runtests.py {posargs:}
 #commands =  python ../tornado/tornado/test/iostream_test.py 
 
 #changedir = {toxworkdir}
+
+[testenv:m2io_https]
+commands = python tornado_m2crypto/test/m2io_https.py


### PR DESCRIPTION
This is still a long way from passing the test suite, but this fixes things to the point of a simple tornado SSL example running correctly, albeit with some horrible hacks:
 * In m2_wrap_socket I add attributes to the connection object (family & server_side): Tornado expects family to be there but M2Crypto Connection doesn't implement it. The server_side flag is added as sometimes a pre-wrapped socket is given to M2IOStream and there is no other way to get this information in that case.
 * TCPServer (the base class for HTTPServer) isn't configurable and calls ssl_wrap_socket, so I have to monkey patch that for the example to work: I can't see any neat way around that at all (short of putting in an upstream request to make TCPServer inherit from Configurable?).
 * The SSL handshake doesn't check the non-blocking error codes properly: I couldn't work out how to get the error code back. There should be an SSL_WANT_READ/WRITE code set somewhere to differentiate a non-blocking return from proper errors.

Regards,
Simon
